### PR TITLE
Make grunt server the default task

### DIFF
--- a/templates/_Gruntfile.js
+++ b/templates/_Gruntfile.js
@@ -99,5 +99,5 @@ module.exports = function (grunt) {
     'watch'
   ]);
 
-  grunt.registerTask('default', 'build');
+  grunt.registerTask('default', 'server');
 };


### PR DESCRIPTION
The default task should be an alias for the most commonly used task. I can't think of the last time I ran `grunt build`, on its own without launching the server.
