### PR TITLE
Add node 0.11 to Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "0.11"
   - "0.10"
   - "0.8"
 before_script:


### PR DESCRIPTION
I want to stay up to date with node and maintain support for 0.11 in preparation for the next stable minor version.
