### PR TITLE
Updated Gruntfile template

### DIFF
--- a/templates/_Gruntfile.js
+++ b/templates/_Gruntfile.js
@@ -20,7 +20,6 @@ module.exports = function (grunt) {
         }
       }
     },<% } %>
-    // Move files not handled by other tasks
     copy: {
       dist: {
         files: [{
@@ -45,8 +44,7 @@ module.exports = function (grunt) {
           'src/pages/**'
         ],
         tasks: ['pages']
-      },
-      <% if (CSSPreprocessorTask) { %>
+      },<% if (CSSPreprocessorTask) { %>
       <%= CSSPreprocessorTask %>: {
         files: ['src/styles/**'],
         tasks: ['<%= CSSPreprocessorTask %>']
@@ -107,5 +105,5 @@ module.exports = function (grunt) {
 
   grunt.registerTask('default', 'server');
 
-  require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+  require('load-grunt-tasks')(grunt);
 };

--- a/templates/_package.json
+++ b/templates/_package.json
@@ -13,7 +13,7 @@
     "connect-livereload": "~0.3.0",
     "grunt-open": "~0.2.0",
     "grunt-contrib-watch": "~0.4.3",
-    "matchdep": "~0.1.1"
+    "load-grunt-tasks": "~0.1.0"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
- List watch tasks in the order they are defined in the config
- Removed comment above copy task
- Use connect-livereload instead of grunt-contrib-livereload
- Use load-grunt-tasks instead of matchdep
- Fixed indentation spacing in grunt-contrib-connect task config
