### PR TITLE
Add BitBalloon deploy option

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -96,6 +96,7 @@ module.exports = function () {
       None: false,
       'GitHub Pages': 'gh-pages',
       'Amazon S3': 's3',
+      'BitBalloon': 'bitballoon',
       FTP: 'ftpush'
     }, function (deployTask, deployTool) {
       if (deployTool === chosenDeployTool) {

--- a/lib/new.js
+++ b/lib/new.js
@@ -258,7 +258,7 @@ function getUserChoices(cliOptions, themeConfig, callback) {
       utils.determineChoice({
         choiceName: 'deployment tool',
         cliFlag: cliOptions.deployTask,
-        choices: ['None', 'GitHub Pages', 'Amazon S3', 'FTP']
+        choices: ['None', 'GitHub Pages', 'Amazon S3', 'BitBalloon', 'FTP']
       }, function (chosenDeploymentTask) {
         siteConfig.setDeployTask(chosenDeploymentTask);
         step();
@@ -313,6 +313,11 @@ function generateProject(siteConfig, themeSourceFolder, callback) {
           bucket: 'your-s3-bucket',
           key: 'your-aws-key',
           secret: 'your-aws-secret'
+        }, null, 2), step);
+      } else if (siteConfig.deployTask === 'bitballoon') {
+        siteConfig.deployCredentialsFile = 'grunt-bitballoon.json';
+        utils.safeWriteFile(siteConfig.siteName + '/' + siteConfig.deployCredentialsFile, JSON.stringify({
+          token: 'your-bitballoon-access-token'
         }, null, 2), step);
       } else if (siteConfig.deployTask === 'ftpush') {
         siteConfig.deployCredentialsFile = '.ftppass';

--- a/templates/Gruntfile.js.jst
+++ b/templates/Gruntfile.js.jst
@@ -100,6 +100,19 @@ module.exports = function (grunt) {
           dest: '/'
         }]
       }
+    }<% } else if (deployTask === 'bitballoon') { %>
+    // Be sure to update the grunt-bitballoon.json file with your BitBalloon access token
+    // You can generate one at https://www.bitballoon.com/applications
+    bb: grunt.file.readJSON('./grunt-bitballoon.json'),
+    bitballoon: {
+      options: {
+        src: 'dist',
+        token: '<?= bb.token ?>'
+      },
+      dev: {
+        // Change this to your BitBalloon site
+        site: 'staging-site.bitballoon.com'
+      }
     }<% } else if (deployTask === 'ftpush') { %>
     // Be sure to update the auth.host property to your hostname and update
     // the .ftppass file with your FTP credentials

--- a/templates/package.json.jst
+++ b/templates/package.json.jst
@@ -14,10 +14,10 @@
     "grunt-contrib-clean": "~0.4.0"<% if (deployTask) { %>,<% if (deployTask === 'gh-pages') {%>
     "grunt-gh-pages": "~0.8.0"<% } else if (deployTask === 's3') { %>
     "grunt-s3": "~0.2.0-alpha.3"<% } else if (deployTask === 'ftpush') { %>
-    "grunt-ftpush": "~0.3.2"<% } } %>
+    "grunt-ftpush": "~0.3.2"<% } else if (deployTask == 'bitballoon') { %>
+    "grunt-bitballoon": "~0.1.2"<% } } %>
   },
   "engines": {
     "node": ">=0.10.0"
   }
 }
-


### PR DESCRIPTION
This adds BitBalloon as a deploy option.

BitBalloon is a static hosting service. Here's a few of the things BitBalloon does:
- Atomic deploys (with versions and easy rollback)
- CDN integration (with content addressable URLs, perfect cache-headers and instant cache invalidation)
- Easily setup staging/production sites
- Pretty URLs
- Supports redirects and rewrites
- HTML Forms work (contact forms, etc, automatically works)
- HTTPS (coming to custom domains very soon)
